### PR TITLE
Correct errors with navidrome server

### DIFF
--- a/flozz_daily_mix/__main__.py
+++ b/flozz_daily_mix/__main__.py
@@ -73,27 +73,31 @@ def import_music_to_database(subsonic, db):
     count = 0
     for track in get_tracks(subsonic):
         count += 1
-        db.insert_track(
-            id_=track["id"],
-            albumArtistId=track["_albumArtistId"],
-            artistId=track["artistId"],
-            albumId=track["albumId"],
-            coverArtId=track.get("coverArt", None),
-            genreId=None,  # XXX
-            diskNumber=track.get("discNumber", 1),
-            trackNumber=track.get("track", 1),
-            name=track["title"],
-            sortName=track.get("sortName", track["title"]),
-            duration=track["duration"],
-            year=track.get("year", 0),
-            created=track["created"],
-            starred=True if "starred" in track and track["starred"] else False,
-            rating=track.get("userRating", track["_albumRating"]),
-            playCount=track.get("playCount", 0),
-            lastPlayed=(
-                track["played"] if "played" in track and track["played"] else None
-            ),
-        )
+        try:
+            db.insert_track(
+                id_=track["id"],
+                albumArtistId=track["_albumArtistId"],
+                artistId=track["artistId"],
+                albumId=track["albumId"],
+                coverArtId=track.get("coverArt", None),
+                genreId=None,  # XXX
+                diskNumber=track.get("discNumber", 1),
+                trackNumber=track.get("track", 1),
+                name=track["title"],
+                sortName=track.get("sortName", track["title"]),
+                duration=track["duration"],
+                year=track.get("year", 0),
+                created=track["created"],
+                starred=True if "starred" in track and track["starred"] else False,
+                rating=track.get("userRating", track["_albumRating"]),
+                playCount=track.get("playCount", 0),
+                lastPlayed=(
+                    track["played"] if "played" in track and track["played"] else None
+                ),
+            )
+        # Sometime get track with empty title and some key missing, ignore this track
+        except KeyError:
+            count += -1
     logging.debug("    Imported %i track(s)." % count)
 
     db.commit()

--- a/flozz_daily_mix/subsonic.py
+++ b/flozz_daily_mix/subsonic.py
@@ -48,7 +48,7 @@ class SubsonicClient:
         if "subsonic-response" not in parsed_json:
             raise Exception("Invalid response from the Subsonic API")  # XXX
         if parsed_json["subsonic-response"]["status"] != "ok":
-            raise Exception()  # XXX
+            raise Exception(parsed_json["subsonic-response"]["error"]["message"])  # XXX
         return parsed_json["subsonic-response"]
 
     def getArtists(self, **kwargs):
@@ -61,7 +61,11 @@ class SubsonicClient:
         query = {"type": type_, "offset": offset, "size": size, **kwargs}
         url = self._build_url("getAlbumList", **query)
         response = self._get_json(url)
-        return response["albumList"]["album"]
+        try:
+            return response["albumList"]["album"]
+        # Sometime get empty json response
+        except KeyError:
+            return None
 
     def getAlbum(self, id_=None, **kwargs):
         if not id_:


### PR DESCRIPTION
I tested your daily-mix with my [Navidrome](https://www.navidrome.org/) server.
I needed to make some fix for the script not raise errors.
1. Sometimes the json response from **getAlbumList** is empty
2. Some track are returned with empty title and some key missing like "artistId" or "duration", just ignore this tracks